### PR TITLE
Add instruction on how to get serial module

### DIFF
--- a/Changes to Serial on BrickPi.txt
+++ b/Changes to Serial on BrickPi.txt
@@ -1,3 +1,5 @@
+To get the serial module run this command on Raspbian: sudo apt-get install python-serial
+
 Changes to use the Serial Port
 
 http://www.hobbytronics.co.uk/raspberry-pi-serial-port


### PR DESCRIPTION
Adding "sudo apt-get install python-serial" so users know where to find the python serial library/module
