### PR TITLE
avoid orphaned index.html files when testing for internet connectivity

### DIFF
--- a/Setup Files/install.sh
+++ b/Setup Files/install.sh
@@ -24,7 +24,7 @@ read
 echo " "
 echo "Check for internet connectivity..."
 echo "=================================="
-wget -q --tries=2 --timeout=20 http://google.com
+wget -q --tries=2 --timeout=20 --output-document=/dev/null http://raspberrypi.org
 if [[ $? -eq 0 ]];then
 	echo "Connected"
 else


### PR DESCRIPTION
when using wget to test for internet connectivity, redirect the output to /dev/null to avoid leaving orphaned files behind. 