### PR TITLE
Change install script to facilitate installation on a Pi3 / Jessie / Pixel setup

### DIFF
--- a/Setup Files/install.sh
+++ b/Setup Files/install.sh
@@ -112,8 +112,8 @@ if grep -q "console=ttyAMA0,115200 kgdboc=ttyAMA0,115200" /boot/cmdline.txt; the
 else
 	echo "Already Disabled"
 fi
-if grep -q "console=serial0,11520" /boot/cmdline.txdt; then
-    sudo sed -i -e "/console=serial0,11520/d" /boot/cmdline.txt
+if grep -q "console=serial0,115200" /boot/cmdline.txdt; then
+    sudo sed -i -e "/console=serial0,115200/d" /boot/cmdline.txt
 else
     echo "Already Disabled - Part 2"
 fi

--- a/Setup Files/install.sh
+++ b/Setup Files/install.sh
@@ -112,7 +112,7 @@ if grep -q "console=ttyAMA0,115200 kgdboc=ttyAMA0,115200" /boot/cmdline.txt; the
 else
 	echo "Already Disabled"
 fi
-if grep -q "console=serial0,115200" /boot/cmdline.txdt; then
+if grep -q "console=serial0,115200" /boot/cmdline.txt; then
     sudo sed -i -e "/console=serial0,115200/d" /boot/cmdline.txt
 else
     echo "Already Disabled - Part 2"

--- a/Setup Files/install.sh
+++ b/Setup Files/install.sh
@@ -113,7 +113,7 @@ else
 	echo "Already Disabled"
 fi
 if grep -q "console=serial0,115200" /boot/cmdline.txt; then
-    sudo sed -i -e "/console=serial0,115200/d" /boot/cmdline.txt
+    sudo sed -i -e 's/console=serial0,115200//g' /boot/cmdline.txt
 else
     echo "Already Disabled - Part 2"
 fi


### PR DESCRIPTION
Mostly remove serial login. Add a few Pi3 related changes. 

@Shoban94 and @karan259 , can you both take a look please? 

With this, to install on a brand new Raspbian, one needs to : 
1. clone this repo
2. clone BrickPi_Python repo
3. run install.sh in BrickPi/Setup Files
4. reboot
5. run python setup.py install in BrickPi_Python
